### PR TITLE
Support creating a driver directly without registering it

### DIFF
--- a/driver.go
+++ b/driver.go
@@ -23,6 +23,10 @@ type Driver struct {
 	cfg *Config
 }
 
+func NewDriver(cfg *Config) *Driver {
+	return &Driver{cfg}
+}
+
 func init() {
 	var drv driver.Driver = &Driver{}
 	sql.Register("athena", drv)


### PR DESCRIPTION
In some cases it's useful to reuse drivers to prevent leaking drivers every
time a connection is opened. This allows library users to register the driver
themselves and reuse the registered name when necessary.