### PR TITLE
Use 24-hour format for timestamp

### DIFF
--- a/db_test.go
+++ b/db_test.go
@@ -57,6 +57,15 @@ func TestQuery(t *testing.T) {
 			StringType:    "another string",
 			TimestampType: athenaTimestamp(time.Date(2017, 12, 3, 1, 11, 12, 0, time.UTC)),
 		},
+		{
+			SmallintType:  9,
+			IntType:       8,
+			BigintType:    0,
+			BooleanType:   false,
+			DoubleType:    1.235,
+			StringType:    "another string",
+			TimestampType: athenaTimestamp(time.Date(2017, 12, 3, 20, 11, 12, 0, time.UTC)),
+		},
 	}
 	expectedTypeNames := []string{"varchar", "smallint", "integer", "bigint", "boolean", "double", "varchar", "timestamp"}
 	harness.uploadData(expected)

--- a/value.go
+++ b/value.go
@@ -11,7 +11,7 @@ import (
 
 const (
 	// TimestampLayout is the Go time layout string for an Athena `timestamp`.
-	TimestampLayout = "2006-01-02 03:04:05.999"
+	TimestampLayout = "2006-01-02 15:04:05.999"
 )
 
 func convertRow(columns []*athena.ColumnInfo, in []*athena.Datum, ret []driver.Value) error {


### PR DESCRIPTION
@tejasmanohar The current timestamp format doesn't work with 24-hour timestamps. As an example `2018-02-01 20:41:59.000` will get an `hour out of range` error