### PR TITLE
Adds support for timestamps with a timezone

### DIFF
--- a/value.go
+++ b/value.go
@@ -12,6 +12,8 @@ import (
 const (
 	// TimestampLayout is the Go time layout string for an Athena `timestamp`.
 	TimestampLayout = "2006-01-02 15:04:05.999"
+	// TimestampWithTimeZoneLayout is the Go time layout string for an Athena `timestamp with time zone`.
+	TimestampWithTimeZoneLayout = "2006-01-02 15:04:05.999 MST"
 )
 
 func convertRow(columns []*athena.ColumnInfo, in []*athena.Datum, ret []driver.Value) error {
@@ -54,6 +56,8 @@ func convertValue(athenaType string, rawValue *string) (interface{}, error) {
 		return val, nil
 	case "timestamp":
 		return time.Parse(TimestampLayout, val)
+	case "timestamp with time zone":
+		return time.Parse(TimestampWithTimeZoneLayout, val)
 	default:
 		panic(fmt.Errorf("unknown type `%s` with value %s", athenaType, val))
 	}


### PR DESCRIPTION
Athena supports the Presto [timestamp with timezone](https://prestodb.io/docs/current/functions/datetime.html).

When any field value is of this type in the result of Athena call, this library panic's.

This PR adds the new type.