### PR TITLE
Fix env variable name in documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ environment variables, but you can use anything supported by the
 [Default Credential Provider Chain].
 
 The tests support a few environment variables:
-- `ATHENA_DATBASE` can be used to override the default database "go_athena_tests"
+- `ATHENA_DATABASE` can be used to override the default database "go_athena_tests"
 - `S3_BUCKET` can be used to override the default S3 bucket of "go-athena-tests"
 
 


### PR DESCRIPTION
Seems there was a typo in the variable name in the `README.md`. According to https://github.com/segmentio/go-athena/blob/master/db_test.go#L28, the variable is `ATHENA_DATABASE`. This PR fixes that typo.