### PR TITLE
Accommodate 'timestamp with time zone' Athena column type

### DIFF
--- a/value.go
+++ b/value.go
@@ -12,6 +12,8 @@ import (
 const (
 	// TimestampLayout is the Go time layout string for an Athena `timestamp`.
 	TimestampLayout = "2006-01-02 15:04:05.999"
+	// TimestampWithTimezoneLayout is the Go time layout string for an Athena `timestamp with time zone`.
+	TimestampWithTimezoneLayout = "2006-01-02 15:04:05.999 MST"
 )
 
 func convertRow(columns []*athena.ColumnInfo, in []*athena.Datum, ret []driver.Value) error {
@@ -56,6 +58,8 @@ func convertValue(athenaType string, rawValue *string) (interface{}, error) {
 		return val, nil
 	case "timestamp":
 		return time.Parse(TimestampLayout, val)
+	case "timestamp with time zone":
+		return time.Parse(TimestampWithTimezoneLayout, val)
 	default:
 		panic(fmt.Errorf("unknown type `%s` with value %s", athenaType, val))
 	}


### PR DESCRIPTION
Was seeing this when trying to read timestamp columns that include time zones: 
```
unknown type `timestamp with time zone` with value 2018-10-16 00:03:00.000 UTC
```