### PR TITLE
new 'json' type, used in Athena Queries what use 'cast (col as json)'

### DIFF
--- a/value.go
+++ b/value.go
@@ -54,7 +54,7 @@ func convertValue(athenaType string, rawValue *string) (interface{}, error) {
 		return strconv.ParseFloat(val, 32)
 	case "double", "decimal":
 		return strconv.ParseFloat(val, 64)
-	case "varchar", "string":
+	case "varchar", "string", "json":
 		return val, nil
 	case "timestamp":
 		return time.Parse(TimestampLayout, val)


### PR DESCRIPTION
When using 'CAST' to a type of 'JSON' in a Athena Query Json type causes an error.