### PR TITLE
Optionally read arrays as strings

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -12,9 +12,10 @@ import (
 )
 
 type conn struct {
-	athena         athenaiface.AthenaAPI
-	db             string
-	OutputLocation string
+	athena          athenaiface.AthenaAPI
+	db              string
+	OutputLocation  string
+	arraysAsStrings bool
 
 	pollFrequency time.Duration
 }
@@ -48,8 +49,9 @@ func (c *conn) runQuery(ctx context.Context, query string) (driver.Rows, error) 
 	}
 
 	return newRows(rowsConfig{
-		Athena:  c.athena,
-		QueryID: queryID,
+		Athena:          c.athena,
+		QueryID:         queryID,
+		arraysAsStrings: c.arraysAsStrings,
 		// todo add check for ddl queries to not skip header(#10)
 		SkipHeader: true,
 	})

--- a/driver.go
+++ b/driver.go
@@ -76,10 +76,11 @@ func (d *Driver) Open(connStr string) (driver.Conn, error) {
 	}
 
 	return &conn{
-		athena:         athena.New(cfg.Session),
-		db:             cfg.Database,
-		OutputLocation: cfg.OutputLocation,
-		pollFrequency:  cfg.PollFrequency,
+		athena:          athena.New(cfg.Session),
+		db:              cfg.Database,
+		OutputLocation:  cfg.OutputLocation,
+		arraysAsStrings: cfg.arraysAsStrings,
+		pollFrequency:   cfg.PollFrequency,
 	}, nil
 }
 
@@ -112,9 +113,10 @@ func Open(cfg Config) (*sql.DB, error) {
 
 // Config is the input to Open().
 type Config struct {
-	Session        *session.Session
-	Database       string
-	OutputLocation string
+	Session         *session.Session
+	Database        string
+	OutputLocation  string
+	arraysAsStrings bool
 
 	PollFrequency time.Duration
 }
@@ -138,6 +140,7 @@ func configFromConnectionString(connStr string) (*Config, error) {
 
 	cfg.Database = args.Get("db")
 	cfg.OutputLocation = args.Get("output_location")
+	cfg.arraysAsStrings = args.Get("arrays_as_strings") == "true"
 
 	frequencyStr := args.Get("poll_frequency")
 	if frequencyStr != "" {

--- a/rows.go
+++ b/rows.go
@@ -10,8 +10,9 @@ import (
 )
 
 type rows struct {
-	athena  athenaiface.AthenaAPI
-	queryID string
+	athena          athenaiface.AthenaAPI
+	queryID         string
+	arraysAsStrings bool
 
 	done          bool
 	skipHeaderRow bool
@@ -19,16 +20,18 @@ type rows struct {
 }
 
 type rowsConfig struct {
-	Athena     athenaiface.AthenaAPI
-	QueryID    string
-	SkipHeader bool
+	Athena          athenaiface.AthenaAPI
+	QueryID         string
+	arraysAsStrings bool
+	SkipHeader      bool
 }
 
 func newRows(cfg rowsConfig) (*rows, error) {
 	r := rows{
-		athena:        cfg.Athena,
-		queryID:       cfg.QueryID,
-		skipHeaderRow: cfg.SkipHeader,
+		athena:          cfg.Athena,
+		queryID:         cfg.QueryID,
+		skipHeaderRow:   cfg.SkipHeader,
+		arraysAsStrings: cfg.arraysAsStrings,
 	}
 
 	shouldContinue, err := r.fetchNextPage(nil)
@@ -82,7 +85,7 @@ func (r *rows) Next(dest []driver.Value) error {
 	// Shift to next row
 	cur := r.out.ResultSet.Rows[0]
 	columns := r.out.ResultSet.ResultSetMetadata.ColumnInfo
-	if err := convertRow(columns, cur.Data, dest); err != nil {
+	if err := convertRow(columns, cur.Data, dest, r.arraysAsStrings); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
A simple alternative to dealing with not being able to [parse Athena arrays](https://github.com/segmentio/go-athena/issues/18) (and the current behavior of panic-ing), here is a path that reads the array as a string if a parameter is set.