### PR TITLE
[FIX] Skip header row when not a DDL query

### DIFF
--- a/db_test.go
+++ b/db_test.go
@@ -126,6 +126,25 @@ func TestOpen(t *testing.T) {
 	require.NoError(t, err, "Query")
 }
 
+func TestDDLQuery(t *testing.T) {
+	harness := setup(t)
+	defer harness.teardown()
+
+	rows := harness.mustQuery("show tables")
+
+	output := make([]string, 0)
+	for rows.Next() {
+		var table string
+
+		err := rows.Scan(&table)
+		assert.NoError(t, err, "rows.Scan()")
+
+		output = append(output, table)
+	}
+
+	assert.Equal(t, 1, len(output), "query output")
+}
+
 type dummyRow struct {
 	NullValue     *struct{}       `json:"nullValue"`
 	SmallintType  int             `json:"smallintType"`


### PR DESCRIPTION
DDL queries on Athena don't return a header row. If query contains a DDL statement, the first row is not skipped when doing a scan.

Closes #10. Thank you @Bobochka for the running code for this. I used this here but just added test case to verify.

Signed-off-by: Riyadh Al Nur <riyadhalnur@verticalaxisbd.com>

![Screenshot from 2019-12-31 18-33-40](https://user-images.githubusercontent.com/3457571/71618770-19a1ab80-2bfc-11ea-93bc-33f891a08ea2.png)
