### PR TITLE
Added support for taking catalog for the database to support S3tables operations through this library

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -13,6 +13,7 @@ import (
 
 type conn struct {
 	athena         athenaAPI
+	catalog        string
 	db             string
 	OutputLocation string
 
@@ -57,11 +58,15 @@ func (c *conn) runQuery(ctx context.Context, query string) (driver.Rows, error) 
 
 // startQuery starts an Athena query and returns its ID.
 func (c *conn) startQuery(ctx context.Context, query string) (string, error) {
+	queryCtx := &types.QueryExecutionContext{
+		Database: aws.String(c.db),
+	}
+	if c.catalog != "" {
+		queryCtx.Catalog = aws.String(c.catalog)
+	}
 	resp, err := c.athena.StartQueryExecution(ctx, &athena.StartQueryExecutionInput{
-		QueryString: aws.String(query),
-		QueryExecutionContext: &types.QueryExecutionContext{
-			Database: aws.String(c.db),
-		},
+		QueryString:           aws.String(query),
+		QueryExecutionContext: queryCtx,
 		ResultConfiguration: &types.ResultConfiguration{
 			OutputLocation: aws.String(c.OutputLocation),
 		},

--- a/db_test.go
+++ b/db_test.go
@@ -140,7 +140,7 @@ func TestDriverWithDBCatalog(t *testing.T) {
 	if tableName == "" {
 		tableName = "catalog_test_table"
 	}
-	connStr := fmt.Sprintf("catalog=%s&db=%s&output_location=s3://%s/output", getDBCatalog(), AthenaDatabase, S3Bucket)
+	connStr := fmt.Sprintf("catalog=%s&db=%s&output_location=s3://%s/output", catalogName, AthenaDatabase, S3Bucket)
 	db, err := sql.Open("athena", connStr)
 	require.NoError(t, err, "Open")
 	defer db.Close()
@@ -269,8 +269,4 @@ func (t athenaDate) String() string {
 
 func (t athenaDate) Equal(t2 athenaDate) bool {
 	return time.Time(t).Equal(time.Time(t2))
-}
-
-func getDBCatalog() string {
-	return os.Getenv("ATHENA_CATALOG")
 }

--- a/driver.go
+++ b/driver.go
@@ -80,6 +80,7 @@ func (d *Driver) Open(connStr string) (driver.Conn, error) {
 	return &conn{
 		athena:         athena.NewFromConfig(*cfg.Config),
 		db:             cfg.Database,
+		catalog:        cfg.Catalog,
 		OutputLocation: cfg.OutputLocation,
 		pollFrequency:  cfg.PollFrequency,
 	}, nil
@@ -116,6 +117,7 @@ func Open(cfg DriverConfig) (*sql.DB, error) {
 type DriverConfig struct {
 	Config         *aws.Config
 	Database       string
+	Catalog        string
 	OutputLocation string
 
 	PollFrequency time.Duration
@@ -139,6 +141,7 @@ func configFromConnectionString(ctx context.Context, connStr string) (*DriverCon
 	cfg.Config = &awsConfig
 
 	cfg.Database = args.Get("db")
+	cfg.Catalog = args.Get("catalog")
 	cfg.OutputLocation = args.Get("output_location")
 
 	frequencyStr := args.Get("poll_frequency")


### PR DESCRIPTION
At first, thanks a lot for creating this small, yet very useful library that implements [sql](https://pkg.go.dev/database/sql) abstraction for AWS Athena. 

With the introduction of S3tables, a managed Apache Iceberg offering from AWS, the Athena's query execution input should include the S3 table bucket information through `Catalog` property. This PR extends the driver to allow for specifying the catalog name in the connection string and use it in the query context accordingly. 

An integration test has been added to verify that the simple SQL queries work on the S3 table bucket by providing the catalog information. Here is the output 

```bash
> go test -v -run TestDriverWithCatalog          
=== RUN   TestDriverWithCatalog
--- PASS: TestDriverWithCatalog (21.72s)
PASS
ok      github.com/segmentio/go-athena  22.012s
```
