### PR TITLE
Chore/apply parsyl changes

### DIFF
--- a/db_test.go
+++ b/db_test.go
@@ -41,6 +41,7 @@ func TestQuery(t *testing.T) {
 
 	expected := []dummyRow{
 		{
+			TinyintType:   1,
 			SmallintType:  1,
 			IntType:       2,
 			BigintType:    3,
@@ -53,6 +54,7 @@ func TestQuery(t *testing.T) {
 			DecimalType:   1001,
 		},
 		{
+			TinyintType:   7,
 			SmallintType:  9,
 			IntType:       8,
 			BigintType:    0,
@@ -65,6 +67,7 @@ func TestQuery(t *testing.T) {
 			DecimalType:   0,
 		},
 		{
+			TinyintType:   7,
 			SmallintType:  9,
 			IntType:       8,
 			BigintType:    0,
@@ -77,8 +80,8 @@ func TestQuery(t *testing.T) {
 			DecimalType:   0.48,
 		},
 	}
-	expectedTypeNames := []string{"varchar", "smallint", "integer", "bigint", "boolean", "float", "double", "varchar", "timestamp", "date", "decimal"}
-	harness.uploadData(ctx, expected)
+	expectedTypeNames := []string{"varchar", "tinyint", "smallint", "integer", "bigint", "boolean", "float", "double", "varchar", "timestamp", "date", "decimal"}
+	harness.uploadData(expected)
 
 	rows := harness.mustQuery(ctx, "select * from %s", harness.table)
 	index := -1
@@ -89,6 +92,7 @@ func TestQuery(t *testing.T) {
 		require.NoError(t, rows.Scan(
 			&row.NullValue,
 
+			&row.TinyintType,
 			&row.SmallintType,
 			&row.IntType,
 			&row.BigintType,
@@ -131,6 +135,7 @@ func TestOpen(t *testing.T) {
 
 type dummyRow struct {
 	NullValue     *struct{}       `json:"nullValue"`
+	TinyintType   int             `json:"tinyintType"`
 	SmallintType  int             `json:"smallintType"`
 	IntType       int             `json:"intType"`
 	BigintType    int             `json:"bigintType"`
@@ -170,6 +175,7 @@ func (a *athenaHarness) setupTable(ctx context.Context) {
 	a.table = "t_" + strings.Replace(id.String(), "-", "_", -1)
 	a.mustExec(ctx, `CREATE EXTERNAL TABLE %[1]s (
 	nullValue string,
+	tinyintType tinyint,
 	smallintType smallint,
 	intType int,
 	bigintType bigint,

--- a/db_test.go
+++ b/db_test.go
@@ -81,7 +81,7 @@ func TestQuery(t *testing.T) {
 		},
 	}
 	expectedTypeNames := []string{"varchar", "tinyint", "smallint", "integer", "bigint", "boolean", "float", "double", "varchar", "timestamp", "date", "decimal"}
-	harness.uploadData(expected)
+	harness.uploadData(ctx, expected)
 
 	rows := harness.mustQuery(ctx, "select * from %s", harness.table)
 	index := -1
@@ -123,7 +123,7 @@ func TestOpen(t *testing.T) {
 	awsConfig, err := config.LoadDefaultConfig(context.Background())
 	require.NoError(t, err, "LoadDefaultConfig")
 	db, err := Open(DriverConfig{
-		Config: &awsConfig,
+		Config:         &awsConfig,
 		Database:       AthenaDatabase,
 		OutputLocation: fmt.Sprintf("s3://%s/noop", S3Bucket),
 	})

--- a/rows.go
+++ b/rows.go
@@ -95,7 +95,7 @@ func (r *rows) Next(dest []driver.Value) error {
 func (r *rows) fetchNextPage(ctx context.Context, token *string) (bool, error) {
 	var err error
 	r.out, err = r.athena.GetQueryResults(ctx, &athena.GetQueryResultsInput{
-		MaxResults:       aws.Int64(1000),
+		MaxResults:       aws.Int32(1000),
 		QueryExecutionId: aws.String(r.queryID),
 		NextToken:        token,
 	})

--- a/rows.go
+++ b/rows.go
@@ -95,6 +95,7 @@ func (r *rows) Next(dest []driver.Value) error {
 func (r *rows) fetchNextPage(ctx context.Context, token *string) (bool, error) {
 	var err error
 	r.out, err = r.athena.GetQueryResults(ctx, &athena.GetQueryResultsInput{
+		MaxResults:       aws.Int64(1000),
 		QueryExecutionId: aws.String(r.queryID),
 		NextToken:        token,
 	})

--- a/value.go
+++ b/value.go
@@ -2,8 +2,10 @@ package athena
 
 import (
 	"database/sql/driver"
+	"encoding/hex"
 	"fmt"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/aws/aws-sdk-go-v2/service/athena/types"
@@ -36,6 +38,8 @@ func convertValue(athenaType string, rawValue *string) (interface{}, error) {
 
 	val := *rawValue
 	switch athenaType {
+	case "tinyint":
+		return strconv.ParseInt(val, 10, 8)
 	case "smallint":
 		return strconv.ParseInt(val, 10, 16)
 	case "integer":
@@ -56,6 +60,25 @@ func convertValue(athenaType string, rawValue *string) (interface{}, error) {
 		return strconv.ParseFloat(val, 64)
 	case "varchar", "string":
 		return val, nil
+	case "varbinary", "binary":
+		arr := strings.Split(val, " ")
+		dst := make([]byte, 1)
+		ret := make([]byte, len(arr))
+		for i, v := range arr {
+			src := []byte(v)
+			if len(src) != 2 {
+				return nil, fmt.Errorf("unexpected byte length %d", len(src))
+			}
+			n, err := hex.Decode(dst, src)
+			if err != nil {
+				return nil, err
+			}
+			if n != 1 {
+				return nil, fmt.Errorf("unexpected byte length %d", n)
+			}
+			ret[i] = dst[0]
+		}
+		return ret, nil
 	case "timestamp":
 		return time.Parse(TimestampLayout, val)
 	case "timestamp with time zone":


### PR DESCRIPTION
upgrade to a recent version of the upstream go-athena repo, then apply the changes done by parsyl in their fork in https://github.com/parsyl/go-athena.git

Main change is adding support for the `tinyint` and `varbinary` /  `binary` datatypes, that are supported by Athena but not in the upstream `go-athena` module